### PR TITLE
refactor: make passcode and nickname optional in startExam schema

### DIFF
--- a/src/controllers/exam.controller.ts
+++ b/src/controllers/exam.controller.ts
@@ -132,10 +132,14 @@ async function getExamDetails(req: CustomRequest, res: Response) {
 
 async function startExam(req: CustomRequest, res: Response) {
 	try {
-		const { examId, passcode, nickname } = req.body as {
+		const {
+			examId,
+			passcode = "",
+			nickname = null,
+		} = req.body as {
 			examId: string;
-			passcode: string;
-			nickname: string | null;
+			passcode?: string;
+			nickname?: string;
 		};
 		const userId = req.session.user?.userId;
 

--- a/src/schemas/exam.schema.ts
+++ b/src/schemas/exam.schema.ts
@@ -96,8 +96,8 @@ export const examSchemas = {
 
 	startExam: z.object({
 		examId: objectIdSchema,
-		passcode: z.string().min(1, "Passcode is required"),
-		nickname: z.string().nullable(),
+		passcode: z.string().min(1, "Passcode is required").optional(),
+		nickname: z.string().optional(),
 	}),
 	finishExam: z.object({
 		examId: objectIdSchema,


### PR DESCRIPTION
This change has been adjusted according to the API_DOCS.md documentation.
Exams became joinable without unnecessary fields.